### PR TITLE
Minimal upstream alignment 

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -3,7 +3,7 @@ src-git luci https://github.com/openwrt/luci.git;for-15.05
 src-git routing https://github.com/openwrt-routing/packages.git;for-15.05
 src-git telephony https://github.com/openwrt/telephony.git;for-15.05
 src-git management https://github.com/openwrt-management/packages.git;for-15.05
-src-git arduino git@github.com:arduino/openwrt-arduino-packages.git;for-15.05
+src-git arduino https://github.com/arduino/openwrt-arduino-packages.git
 src-git custom https://github.com/RedSnake64/openwrt-custom-packages.git;for-15.05
 src-git owrt_pub_feeds git://github.com/remakeelectric/owrt_pub_feeds.git
 src-git juci https://github.com/mkschreder/juci-openwrt-feed.git

--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -173,8 +173,8 @@ foreach my $mirror (@ARGV) {
 			push @extra, "$extra[0]/longterm/v$1";
 		}		
 		foreach my $dir (@extra) {
-			push @mirrors, "ftp://ftp.all.kernel.org/pub/$dir";
-			push @mirrors, "http://ftp.all.kernel.org/pub/$dir";
+			push @mirrors, "https://kernel.org/pub/$dir";
+			push @mirrors, "ftp://kernel.org/pub/$dir";
 		}
     } elsif ($mirror =~ /^\@GNOME\/(.+)$/) {
 		push @mirrors, "http://ftp.gnome.org/pub/GNOME/sources/$1";


### PR DESCRIPTION
1) openwrt-arduino-packages.git was not reachable using git the protocol, switch feed to use https instead.
2) Applied upstream patch where the kernel mirrors swtiched from FTP to HTTP. 